### PR TITLE
Rename userid to user_id on classes table

### DIFF
--- a/app/Http/Livewire/Assignments/AssignmentCreate.php
+++ b/app/Http/Livewire/Assignments/AssignmentCreate.php
@@ -80,7 +80,7 @@ class AssignmentCreate extends Component {
 
     $this->assignment->status = 'inc';
 
-    $classes = Classes::where('userid', Auth::User()->id)->get();
+    $classes = Classes::where('user_id', Auth::User()->id)->get();
     foreach ($classes as $class)
       $this->classes[] = ['id' => $class->id, 'name' => $class->name];
   }

--- a/app/Http/Livewire/Assignments/AssignmentEdit.php
+++ b/app/Http/Livewire/Assignments/AssignmentEdit.php
@@ -79,7 +79,7 @@ class AssignmentEdit extends Component {
 
     $this->assignment->link = isset($this->assignment->link) ? Crypt::decryptString($this->assignment->link) : $this->assignment->link;
 
-    $classes = Classes::where('userid', Auth::User()->id)->get();
+    $classes = Classes::where('user_id', Auth::User()->id)->get();
     foreach ($classes as $class)
       $this->classes[] = ['id' => $class->id, 'name' => $class->name];
   }

--- a/app/Http/Livewire/Assignments/AssignmentList.php
+++ b/app/Http/Livewire/Assignments/AssignmentList.php
@@ -59,7 +59,7 @@ class AssignmentList extends Component {
    * @return void
    */
   public function mount(): void {
-    $usersClasses = Classes::where('userid', Auth::User()->id)->get();
+    $usersClasses = Classes::where('user_id', Auth::User()->id)->get();
     foreach ($usersClasses as $class)
       $this->classes[] = ['id' => $class->id, 'name' => $class->name];
 

--- a/app/Models/Classes.php
+++ b/app/Models/Classes.php
@@ -10,7 +10,7 @@ class Classes extends Model {
 
   protected $table = 'classes';
 
-  protected $guarded = ['id', 'userid'];
+  protected $guarded = ['id', 'user_id'];
 
   protected $casts = [
     'name' => 'encrypted',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -95,7 +95,7 @@ class User extends Authenticatable implements FilamentUser {
   }
 
   public function getNumClassesAttribute() {
-    return Classes::where('userid', Auth::user()->id)->count();
+    return Classes::where('user_id', Auth::user()->id)->count();
   }
 
   public function getNameAttribute() {
@@ -123,7 +123,7 @@ class User extends Authenticatable implements FilamentUser {
   }
 
   public function classes() {
-    return $this->hasMany(Classes::class, 'userid');
+    return $this->hasMany(Classes::class, 'user_id');
   }
 
   public function schedules() {

--- a/app/Rules/UniquePeriod.php
+++ b/app/Rules/UniquePeriod.php
@@ -8,42 +8,41 @@ use Illuminate\Contracts\Validation\Rule;
 
 use Illuminate\Support\Facades\Auth;
 
-class UniquePeriod implements Rule
-{
-    public $value;
+class UniquePeriod implements Rule {
+  public $value;
 
-    /**
-     * Create a new rule instance.
-     *
-     * @return void
-     */
-    public function __construct(){
-        //
-    }
+  /**
+   * Create a new rule instance.
+   *
+   * @return void
+   */
+  public function __construct() {
+    //
+  }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value){
-      $this->value = $value;
-      if($value < 1)
-        return false;
-      return ! Classes::where(['period' => $value, 'userid' => Auth::User()->id])->exists();
-    }
+  /**
+   * Determine if the validation rule passes.
+   *
+   * @param  string  $attribute
+   * @param  mixed  $value
+   * @return bool
+   */
+  public function passes($attribute, $value) {
+    $this->value = $value;
+    if ($value < 1)
+      return false;
+    return !Classes::where(['period' => $value, 'user_id' => Auth::User()->id])->exists();
+  }
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(){
-        if ($this->value < 1)
-          return 'Invalid period';
-        else
-          return 'Period already used';
-    }
+  /**
+   * Get the validation error message.
+   *
+   * @return string
+   */
+  public function message() {
+    if ($this->value < 1)
+      return 'Invalid period';
+    else
+      return 'Period already used';
+  }
 }

--- a/database/migrations/2022_12_22_121402_rename_classes_table_user_id_column.php
+++ b/database/migrations/2022_12_22_121402_rename_classes_table_user_id_column.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameClassesTableUserIdColumn extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::table('classes', function (Blueprint $table) {
+            $table->renameColumn('userid', 'user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        //
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,7 +103,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
   Route::get('assignments/{class?}/{due?}', function ($class = -1, $due = 'Incomplete') {
     if ($class == 'all')
       $class = -1;
-    if ($class == -1 || Classes::where(['userid' => Auth::User()->id, 'id' => $class])->exists()) {
+    if ($class == -1 || Classes::where(['user_id' => Auth::User()->id, 'id' => $class])->exists()) {
       if (ucfirst($due) != 'Incomplete' && ucfirst($due) != 'Completed')
         abort(404);
       return view('assignments.list', ['class' => $class, 'due' => ucfirst($due)]);


### PR DESCRIPTION
Fixed an issue with improper column names on the classes table by renaming `userid` to `user_id`, establishing consistency