### PR TITLE
Fix issues with body content jumping on modal open

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -31,14 +31,14 @@
 
     <!-- Scripts -->
   </head>
-  <body class="antialiased theme-div mdc-typography overflow-x-hidden @if($theme == "dark") theme-dark @endif @if(Request::is('agenda*')) overflow-y-hidden @endif" id="themer">
+  <body class="antialiased theme-div mdc-typography @if($theme == "dark") theme-dark @endif @if(Request::is('agenda*')) overflow-y-hidden @endif" id="themer">
     <div class="min-h-screen content-div" id="makefixed" wire:ignore.self>
       @livewire('navigation-menu')
 
       <x-ui.snackbar/>
       <x-pwa-snackbar/>
 
-      <main class="min-h-screen pt-20">
+      <main class="min-h-screen pt-20 overflow-x-hidden">
         <div id="main" class="relative">
             {{ $slot }}
         </div>


### PR DESCRIPTION
Closes #2 

Fixed by moving `overflow-x-hidden` class from the body to main. Seems that was causing whatever locked the content in place to jump around the page