### PR TITLE
Agenda items should now appear full width when possible

### DIFF
--- a/app/Classes/Schedule/Event.php
+++ b/app/Classes/Schedule/Event.php
@@ -13,6 +13,10 @@ class Event
 
     public int $bottom;
 
+    public int $width;
+
+    public bool $fullWidth = false;
+
     public function __construct(
         public Carbon $date,
         public int $id,


### PR DESCRIPTION
Agenda items now fill the remaining columns when they have no neighbors 

<img width="1030" alt="image" src="https://github.com/a-batts/schedulist/assets/12241573/79576cd3-990a-4fc7-94e9-e0531be16ea2">
